### PR TITLE
Dates3

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,6 +1,7 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the `rails generate channel` command.
 //
+//= require action_cable
 //= require_self
 //= require_tree ./channels
 

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -13,4 +13,9 @@
   color: white !important;
 }
 
+.modal-title-preview {
+  font-family: $bebas;
+  color: $bv-hangar !important;
+}
+
 

--- a/app/views/events/_event-banner.html.erb
+++ b/app/views/events/_event-banner.html.erb
@@ -2,7 +2,7 @@
 
     <div class="banner-event" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url('<%= cl_image_path @event.photo, :width => 1300, :height => 780, crop: :fill, class:"d-block w-100"%>');">
       <div class="container">
-        <h1><%= @event[:name]%> </h1>
+        <h1><%= @event[:name]%></h1>
         <br><div class="e-date">
           <h3><%= @event[:start_date].strftime("%d %B %Y | %Hh%M") %></h3>
           <h3>  <%= @event[:end_date].strftime("- %d %B %Y | %Hh%M") %>

--- a/app/views/events/_event-banner.html.erb
+++ b/app/views/events/_event-banner.html.erb
@@ -4,8 +4,8 @@
       <div class="container">
         <h1><%= @event[:name]%></h1>
         <br><div class="e-date">
-          <h3><%= @event[:start_date].strftime("%d %B %Y | %Hh%M") %></h3>
-          <h3>  <%= @event[:end_date].strftime("- %d %B %Y | %Hh%M") %>
+          <h3><%= @event[:start_date].strftime("%d %B %Y") %></h3>
+          <h3>  <%= @event[:end_date].strftime("- %d %B %Y") %>
           </h3>
           <% if current_user.profile.is_bar_manager %>
             <p><%= link_to 'Edit event', edit_event_path(@event), class: "bw-border-tbg" %></p>
@@ -21,8 +21,8 @@
       <div class="container">
         <h1><%= @event[:name]%> </h1>
         <br><div class="e-date">
-          <h3><%= @event[:start_date].strftime("%d %B %Y | %Hh%M") %></h3>
-            <h3>  <%= @event[:end_date].strftime("- %d %B %Y | %Hh%M") %>
+          <h3><%= @event[:start_date].strftime("%d %B %Y") %></h3>
+            <h3>  <%= @event[:end_date].strftime("- %d %B %Y") %>
             </h3>
               <% if current_user.profile.is_bar_manager %>
                 <p><%= link_to 'Edit event', edit_event_path(@event), class: "bw-border-tbg" %></p>

--- a/app/views/events/_events_list.html.erb
+++ b/app/views/events/_events_list.html.erb
@@ -14,8 +14,8 @@
       <div class="col-sm-4">
         <div class="card" style="background-image: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.2)), url('<%= event.photo %>');">
           <p class="title"><%= event.name %></p>
-          <p class="white"><%= event.start_date.strftime("%a %B %d | %H:%M") %></p>
-          <p class="white"><%= event.end_date.strftime("%a %B %d | %H:%M") %></p>
+          <p class="white"><%= event.start_date.strftime("%a %B %d") %></p>
+          <p class="white"><%= event.end_date.strftime("%a %B %d") %></p>
           <% if current_user %>
             <%= link_to "Show", event_path(event), class: "button" %>
           <% else %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -5,8 +5,8 @@
   <%= f.error_notification %>
 
   <%= f.input :name %>
-  <%= f.input :start_date, order: [:day, :month, :year] %>
-  <%= f.input :end_date, order: [:day, :month, :year] %>
+  <%= f.input :start_date, as: :date, html5: true %>
+  <%= f.input :end_date, as: :date, html5: true %>
   <%= f.input :description %>
   <%= f.input :category, collection: ["Concert", "Exhibition", "Performance"] %>
   <%= f.input :bar_id, collection: current_user.bars, value_method: :id %>

--- a/app/views/events/_new_modal.html.erb
+++ b/app/views/events/_new_modal.html.erb
@@ -22,8 +22,8 @@
               <%= f.error_notification %>
 
               <%= f.input :name %>
-              <%= f.input :start_date, order: [:day, :month, :year] %>
-              <%= f.input :end_date, order: [:day, :month, :year] %>
+              <%= f.input :start_date, as: :date, html5: true %>
+              <%= f.input :end_date, as: :date, html5: true %>
               <%= f.input :description %>
               <%= f.input :category, collection: ["Concert", "Exhibition", "Performance"] %>
               <%= f.input :bar_id, collection: current_user.bars, value_method: :id %>

--- a/app/views/pages/_modal_prev.html.erb
+++ b/app/views/pages/_modal_prev.html.erb
@@ -3,7 +3,7 @@
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h1 class="modal-title" id="exampleModalLongTitle">
+        <h1 class="modal-title-preview" id="exampleModalLongTitle">
           <%= event.name %> 💡
         </h1>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -17,9 +17,9 @@
           <h2><%= link_to event.user.profile.username.capitalize, profile_path(event.user),class:"blue-link" %>, </h2>
           <h2>at <%= link_to event.bar.name, bar_path(event.bar), class:"blue-link"%></h2>
           <p> from
-                <%= event.start_date %>
+                <%= event.start_date.strftime("%a %B %d") %>
           </p>
-          <p>   to <%= event.end_date %>
+          <p>   to <%= event.end_date.strftime("%a %B %d") %>
           </p>
           <h4>
               <%= link_to "See artist profile

--- a/db/migrate/20190829090407_change_start_date_to_be_date_in_events.rb
+++ b/db/migrate/20190829090407_change_start_date_to_be_date_in_events.rb
@@ -1,0 +1,5 @@
+class ChangeStartDateToBeDateInEvents < ActiveRecord::Migration[5.2]
+  def change
+    change_column :events, :start_date, :date
+  end
+end

--- a/db/migrate/20190829090511_change_end_date_to_be_date_in_events.rb
+++ b/db/migrate/20190829090511_change_end_date_to_be_date_in_events.rb
@@ -1,0 +1,5 @@
+class ChangeEndDateToBeDateInEvents < ActiveRecord::Migration[5.2]
+  def change
+    change_column :events, :end_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_161427) do
+ActiveRecord::Schema.define(version: 2019_08_29_090511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,8 +51,8 @@ ActiveRecord::Schema.define(version: 2019_08_28_161427) do
     t.bigint "bar_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "start_date"
-    t.datetime "end_date"
+    t.date "start_date"
+    t.date "end_date"
     t.boolean "confirmed", default: false
     t.string "category"
     t.index ["bar_id"], name: "index_events_on_bar_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -273,17 +273,17 @@ end
 
 puts "Creating events"
 
-now = Time.now
+now = Date.today
 
 events = []
 
 bars.each do |bar|
   artists.each_with_index do |artist_user, i|
     # Event starting date between 2 days ago and 144 hours (6 days) from then: to still have more events in present
-    random_start_date = now - 2.days + 60 * 60 * Random.rand(1..144)
+    random_start_date = now - 3.days + Random.rand(1..6).days
 
     # Event duration between 1 - 8 hours
-    random_end_date = random_start_date + 60 * 60 * Random.rand(1..8)
+    random_end_date = random_start_date + Random.rand(1..7).days
     event = Event.new(
       user: artist_user,
       bar: bar,


### PR DESCRIPTION
Basic HTML5 datepicker on event creation/edit form. Now only showing dates on event pages. Changed datatype of start_date and end_date via migration to be consisted. When I was trying out datetime pickers I noticed some jquery was blocked because //= require action_cable was missing (which I removed some time ago, because could'nt load home page), so I re-added it. 